### PR TITLE
Remove unneeded Node.js setup step from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
-
     - name: Install dependencies
-      run: npm i
+      run: npm ci
 
     - name: Run linter
       run: npm run lint


### PR DESCRIPTION
This PR closes #22, updating the CI workflow to remove an unneeded setup step for Node.js.